### PR TITLE
fix: target user when using api key

### DIFF
--- a/api/src/account/account.guard.ts
+++ b/api/src/account/account.guard.ts
@@ -1,16 +1,14 @@
-import { CanActivate, ExecutionContext, HttpStatus } from "@nestjs/common"
+import { CanActivate, ExecutionContext, HttpStatus } from '@nestjs/common'
 
 export class AccountGuard implements CanActivate {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest()
+    const res = context.switchToHttp().getResponse()
+    req['user'] = req.user ?? JSON.parse(JSON.stringify({"sub": req.body['user']}))
 
-    async canActivate(context: ExecutionContext): Promise<boolean> {
-        const req = context.switchToHttp().getRequest()
-        const res = context.switchToHttp().getResponse()
-        const user = req.user
+    if (req.user) return true
 
-        if(user) 
-            return true
-
-        res.sendStatus(HttpStatus.PRECONDITION_REQUIRED)
-        return false
-    }
+    res.sendStatus(HttpStatus.PRECONDITION_REQUIRED)
+    return false
+  }
 }


### PR DESCRIPTION
Before, it was impossible to perform a request related to user while using an api-key, because user-related requests were using the user's JWT Token passed in the headers in order to retrieve the user. Now the user's email/id can be passed in the request body if an api-key is used.